### PR TITLE
pass loggly http client errors to winston continuation

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -108,9 +108,9 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
   //
   // Helper function for responded to logging.
   //
-  function logged() {
+  function logged(err) {
     self.emit('logged');
-    callback(null, true);
+    callback(err, true);
   }
 
   return meta.tags


### PR DESCRIPTION
Background: in the case of a failed attempt to post a message to Loggly, it'd be nice to be able to detect the failure via Winston's `log()` callback param and respond accordingly (write to file, write to console, etc). 

I was perplexed to discover that HTTP errors in the Loggly client don't result in an error being passed back up to continuation functions supplied to winston's `log()` method, and upon reading the source, it appeared to be a simple oversight. 

This single commit enables the expected behavior.
