### PR TITLE
update license and contributors in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,12 @@
   "name": "winston-loggly-bulk",
   "version": "1.3.4",
   "description": "A Loggly transport for winston",
-  "author": "Loggly <sjain@loggly.com>",
+  "author": "Loggly <sjain@loggly.com> (https://github.com/loggly)",
   "contributors": [
-    {
-      "name": "Loggly",
-      "email": "sjain@loggly.com",
-      "url": "https://github.com/loggly"
-    },
-    {
-      "name": "Shweta Jain",
-      "email": "shweta.jain@psquickit.com",
-      "url": "https://github.com/shwetajain148"
-    }
+    "Charlie Robbins <charlie.robbins@gmail.com> (http://www.github.com/indexzero)",
+    "Shweta Jain <shweta.jain@psquickit.com> (https://github.com/shwetajain148)"
   ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/loggly/winston-loggly-bulk.git"


### PR DESCRIPTION
- adding license info for easy lookup
- use short form for contributors, removed `Loggly` as contributer as its author