### PR TITLE
queue support in library "winston-loggly-bulk" and make buffer option configurable 

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -54,7 +54,8 @@ var Loggly = exports.Loggly = function (options) {
     proxy: options.proxy || null,
     token: options.token,
     tags: tags,
-    isBulk: options.isBulk || false
+    isBulk: options.isBulk || false,
+    bufferOptions: options.bufferOptions || {size: 500, retriesInMilliSeconds: 30 * 1000}
   });
 
   this.timestamp = options.timestamp || false;


### PR DESCRIPTION
- As `winston-loggly-bulk` package depends on `node-loggly-bulk`, I have already added all required code for queue management during network outage in node-loggly-bulk library.

-  PR reference for `node-loggly-bulk` library: https://github.com/loggly/node-loggly-bulk/pull/5

Note: Please merger this [PR](https://github.com/loggly/node-loggly-bulk/pull/5) before merging PR for `winston-loggly-bulk`.