### PR TITLE
update version of node-loggly-bulk

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "keywords": ["loggly", "logging", "sysadmin", "tools", "winston"],
   "dependencies": {
-    "node-loggly-bulk": "~1.1.0"
+    "node-loggly-bulk": "^1.2.1"
   },
   "devDependencies": {
     "winston": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "keywords": ["loggly", "logging", "sysadmin", "tools", "winston"],
   "dependencies": {
     "node-loggly-bulk": "^1.2.1",
-    "winston": "^2.3.1"
+    "winston": "1.0.x"
   },
   "devDependencies": {
     "vows": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loggly-bulk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A Loggly transport for winston",
   "author": "Loggly <opensource@loggly.com>",
   "contributors": [
@@ -21,10 +21,10 @@
   },
   "keywords": ["loggly", "logging", "sysadmin", "tools", "winston"],
   "dependencies": {
-    "node-loggly-bulk": "^1.2.1"
+    "node-loggly-bulk": "^1.2.1",
+    "winston": "^2.3.1"
   },
   "devDependencies": {
-    "winston": "1.0.x",
     "vows": "0.8.0"
   },
   "main": "./lib/winston-loggly",


### PR DESCRIPTION
@mchaudhary, @mostlyjason, Updated version of node-loggly-bulk to latest which will resolve the "Security Vulnerability" issue mentioned in #17. Please review and merge it.

Here I have used the "carrot ranges" i.e. "^" symbol which allows Minor release, when functionality is added in backward compatible manner. Here you can find detailed information: 

http://www.hostingadvice.com/how-to/update-npm-packages/
https://github.com/npm/node-semver#caret-ranges-123-025-004