### PR TITLE
upgrade to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loggly-bulk",
-  "version": "1.4.3",
+  "version": "2.0.0",
   "description": "A Loggly transport for winston",
   "author": "Loggly <opensource@loggly.com>",
   "contributors": [
@@ -21,8 +21,8 @@
   },
   "keywords": ["loggly", "logging", "sysadmin", "tools", "winston"],
   "dependencies": {
-    "node-loggly-bulk": "^1.2.1",
-    "winston": "1.0.x"
+    "node-loggly-bulk": "^2.0.0",
+    "winston": "^2.3.1"
   },
   "devDependencies": {
     "vows": "0.8.0"


### PR DESCRIPTION
@mchaudhary @mostlyjason I have raised a PR to update version of **node-loggly-bulk** to version **2.0.0** in package.json file.  

PR: https://github.com/loggly/node-loggly-bulk/pull/12

In this PR, I have updated versions for **winston-loggly-bulk**, **node-loggly-bulk** and **Wisnton**. After merging this PR, all three libraries will be in sync with version 2. 

Please merge node-loggly-bulk's PR (https://github.com/loggly/node-loggly-bulk/pull/12) before merging this one. 