### PR TITLE
helper method to call process exit

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -17,6 +17,8 @@ var events = require('events'),
 //
 var code = /\u001b\[(\d+(;\d+)*)?m/g;
 
+var timerFunctionForProcessExit = null;
+
 //
 // ### function Loggly (options)
 // #### @options {Object} Options for this instance.
@@ -63,6 +65,18 @@ var Loggly = exports.Loggly = function (options) {
 };
 
 //
+// Helper function to call process.exit() after waiting
+// 10 seconds.
+//
+var flushLogsAndExit = exports.flushLogsAndExit = function () {
+    if (timerFunctionForProcessExit === null) {
+      timerFunctionForProcessExit = setInterval(function () {
+        process.exit();
+      },10000);
+    }
+}
+
+//
 // Inherit from `winston.Transport`.
 //
 util.inherits(Loggly, winston.Transport);
@@ -72,6 +86,7 @@ util.inherits(Loggly, winston.Transport);
 // is available and thus backwards compatible.
 //
 winston.transports.Loggly = Loggly;
+winston.transports.flushLogsAndExit = flushLogsAndExit;
 
 //
 // Expose the name of this Transport on the prototype


### PR DESCRIPTION
@mchaudhary, @mostlyjason, I have created and exposed the **flushLogsAndExit** method to call process.exit() after 10 seconds. Users can call this method to call process.exit internally after 10 seconds. 

They will need to do something like below in their app.js file:

```
var winston = require('winston'),
winlog = require('winston-loggly-bulk');

winlog.flushLogsAndExit();
```