### PR TITLE
update package.json file for version upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loggly-bulk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Loggly transport for winston",
   "author": "Loggly <opensource@loggly.com>",
   "contributors": [
@@ -21,7 +21,7 @@
   },
   "keywords": ["loggly", "logging", "sysadmin", "tools", "winston"],
   "dependencies": {
-    "node-loggly-bulk": "^2.0.0",
+    "node-loggly-bulk": "^2.0.1",
     "winston": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
@mchaudhary @mostlyjason, Since I have published the new npm package for **winston-loggly-bulk** i.e. **2.0.1**, here is the pull request to update the version in package.json file.