### PR TITLE
TypeError: winston.transports.Loggly is not a constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "keywords": ["loggly", "logging", "sysadmin", "tools", "winston"],
   "dependencies": {
     "node-loggly-bulk": "^2.0.1",
-    "winston": "^2.3.1"
+    "winston": "2.3.1"
   },
   "devDependencies": {
     "vows": "0.8.0"


### PR DESCRIPTION
Taking winston 2.4.0 doesn't work, so don't