### PR TITLE
Error message support in winston-loggly-bulk

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -119,7 +119,7 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
       self    = this;
 
   message.level = level;
-  message.message = msg;
+  message.message = msg || message.message;
 
   //
   // Helper function for responded to logging.


### PR DESCRIPTION
@mchaudhary @mostlyjason, This PR is to resolve the lost error message issue when logging an error and is related to issue https://github.com/loggly/winston-loggly-bulk/issues/29. I have tested the changes and now the library will include the error message when logging an error. 

