### PR TITLE
Add new flag for network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The Loggly transport is based on [Nodejitsu's][2] [node-loggly][3] implementatio
   - __retriesInMilliSeconds:__ Time in milliseconds to retry sending buffered logs. 
 * __timestamp:__ If false, library will not include timestamp in log events. 
   - __Note:__ Library includes timestamp by default when we do not set timestamp option.
+* __networkErrorsOnConsole:__ The library keep track of different network errors and can log them to console. By default, logging errors on console is disabled and can be enabled easily by setting this parameter's value to `true`. If true, all the network errors will be logged to console.
 
 *Metadata:* Logged in suggested [Loggly format][5]
 

--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -57,7 +57,8 @@ var Loggly = exports.Loggly = function (options) {
     token: options.token,
     tags: tags,
     isBulk: options.isBulk || false,
-    bufferOptions: options.bufferOptions || {size: 500, retriesInMilliSeconds: 30 * 1000}
+    bufferOptions: options.bufferOptions || {size: 500, retriesInMilliSeconds: 30 * 1000},
+    networkErrorsOnConsole: options.networkErrorsOnConsole || false
   });
 
   this.timestamp = options.timestamp === false ? false : true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-loggly-bulk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A Loggly transport for winston",
   "author": "Loggly <opensource@loggly.com>",
   "contributors": [


### PR DESCRIPTION
As per the current scenario, the library writes the networks errors on console which sometimes pollute the other important logs when the numbers are so high. 

In this PR, I have made the error writing to `false` by default and added the new flag variable whose value can be set from the main application file. This variable basically allow the user to set the default value to true which will starts printing  the errors on console. So if any user wants those error logs then he can set the value to `true` easily. 