### PR TITLE
Remove legacy code in log method

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -113,7 +113,7 @@ const validateMetadata = (meta) => {
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Loggly.prototype.log = function (level, msg, meta, callback) {
+Loggly.prototype.log = function (meta, callback) {
 
   const message = validateMetadata(meta);
 
@@ -126,25 +126,24 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
   }
 
   if (this.stripColors) {
-    msg = ('' + msg).replace(code, '');
+    message.message = ('' + message.message).replace(code, '');
   }
 
   const self = this;
-
-  message.level = level;
-  message.message = msg || message.message;
 
   //
   // Helper function for responded to logging.
   //
   function logged(err) {
     self.emit('logged');
-    callback(err, true);
   }
 
-  return (meta && meta.tags)
+  result = (meta && meta.tags)
     ? this.client.log(message, meta.tags, logged)
     : this.client.log(message, logged);
+    
+  callback();
+  return result;
 };
 
 //


### PR DESCRIPTION
In order to use winston 3.x code the log method must accept only two parameters.