### PR TITLE
Append log splats to Loggly message object

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -129,6 +129,12 @@ Loggly.prototype.log = function (meta, callback) {
     message.message = ('' + message.message).replace(code, '');
   }
 
+  const splats = message[Symbol.for("splat")];
+
+  if (splats && splats.length > 0) {
+    message.details = splats;
+  }
+    
   const self = this;
 
   //


### PR DESCRIPTION
Hello there!

After moving over to Winston 3 from Winston 2, I noticed that Winston was now appending all extra logging arguments as "Symbol(splats)" in the final "message" log object.

Specific actions have to be taken in order to forward those splats to Loggly, as extra arguments are not anymore being forwarded to Loggly.

Depending on the logging pattern in a project, splats could contain an Error object, a plain JS object, or a string message. For instance, calling `log.error("An error occured:", new Error("Nah!"))` would set "An error occured:" as `message.message`, but would not forward the `Error` object to Loggly. This PR addresses this "regression" after an upgrade from Winston 2 to 3.

_Notice: `splats` is an array of all extra values passed to the logging function. Providing 4 arguments to the logging call would induce a splats object of length 3._