### PR TITLE
Task/add console log-print on failure to deliver log

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -110,6 +110,9 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
   //
   function logged() {
     self.emit('logged');
+    if (err) {
+      console.error('Loggly Error:', err);
+    }
     callback(null, true);
   }
 

--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -113,7 +113,7 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
     callback(null, true);
   }
 
-  return meta.tags
+  return meta && meta.tags
     ? this.client.log(message, meta.tags, logged)
     : this.client.log(message, logged);
 };


### PR DESCRIPTION
We experienced issues were many log events are missing in Loggly control-panel.
Hippo would appreciate if you can pick up this PR in order for us to be able to debug it on our side and see if the failures are due to network errors or if the logs were submitted properly and failed to get digested on Loggly's side