### PR TITLE
Print an error to console when fails to deliver a log event to Loggly

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -145,6 +145,9 @@ Loggly.prototype.log = function(meta, callback) {
   //
   function logged(err, result) {
     self.emit('logged');
+    if (err) {
+      console.error('Loggly Error:', err);
+    }
     callback && callback(err, result);
   }
 


### PR DESCRIPTION
We experienced issues were many log events are missing in Loggly control-panel.
Hippo would appreciate it if you can pick up this PR in order for us to be able to debug it on our side and see if the failures are due to network errors or if the logs were submitted properly and failed to get digested on Loggly's side.

This is also implemented in PT transport:
https://github.com/kenperkins/winston-papertrail/blob/master/lib/winston-papertrail.js#L482

and would probably help other users debug issues in the future!