### PR TITLE
Handle the case where splats[0] is null

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -131,11 +131,11 @@ Loggly.prototype.log = function(meta, callback) {
   if (splats && splats.length > 0) {
     let details =
       typeof splats[0] === 'object' ? splats.slice(1, splats.length) : splats; //ignore the first object, it's already included in root
-    if (splats[0].details !== undefined) {
+    if (splats[0] && splats[0].details !== undefined) {
       //overwrites the original details prop, so we need to include it
       details = [{ details: splats[0].details }, ...details];
     }
-    if (details.length) data.details = details;
+    if (details && details.length) data.details = details;
   }
 
   const self = this;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "winston-loggly-bulk",
+  "name": "@crisp-fix/winston-loggly-bulk",
   "version": "3.3.2",
   "description": "A Loggly transport for winston",
   "author": "Loggly <opensource@loggly.com>",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@crisp-fix/winston-loggly-bulk",
+  "name": "winston-loggly-bulk",
   "version": "3.3.2",
   "description": "A Loggly transport for winston",
   "author": "Loggly <opensource@loggly.com>",


### PR DESCRIPTION
I've submitted PR #58 fixing missing details, which was merged. Thanks for that.

It looks like my original PR code was rewritten, introducing a new bug. We've seen occurenced in production where splats[0] is null, triggering a `Uncaught TypeError: Cannot read property 'details' of null`.

This PR addresses the issue.